### PR TITLE
Fixing Code Warnings and Pitfalls with Initial Linux Compile Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.vscode/

--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -4,7 +4,7 @@
 add_library(SYSTEM_W7500X_FILES STATIC)
 
 target_sources(SYSTEM_W7500X_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/system_W7500x.c
+        ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/system_w7500x.c
         )
 
 target_include_directories(SYSTEM_W7500X_FILES PUBLIC
@@ -22,7 +22,7 @@ target_sources(GPIO_FILES PUBLIC
         )
 
 target_include_directories(GPIO_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 target_link_libraries(GPIO_FILES PUBLIC
         SYSTEM_W7500X_FILES
@@ -32,11 +32,11 @@ target_link_libraries(GPIO_FILES PUBLIC
 add_library(UART_FILES STATIC)
 
 target_sources(UART_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/W7500x_uart.c
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_uart.c
         )
 
 target_include_directories(UART_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(UART_FILES PUBLIC
@@ -49,11 +49,11 @@ target_link_libraries(UART_FILES PUBLIC
 add_library(ADC_FILES STATIC)
 
 target_sources(ADC_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/w7500x_adc.c
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_adc.c
         )
 
 target_include_directories(ADC_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(ADC_FILES PUBLIC
@@ -64,11 +64,11 @@ target_link_libraries(ADC_FILES PUBLIC
 add_library(CRG_FILES STATIC)
 
 target_sources(CRG_FILES PUBLIC
-${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/w7500x_crg.c
+${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_crg.c
         )
 
 target_include_directories(CRG_FILES PUBLIC
-${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(CRG_FILES PUBLIC
@@ -79,11 +79,11 @@ target_link_libraries(CRG_FILES PUBLIC
 add_library(DUALTIMER_FILES STATIC)
 
 target_sources(DUALTIMER_FILES PUBLIC
-${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/w7500x_dualtimer.c
+${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_dualtimer.c
         )
 
 target_include_directories(DUALTIMER_FILES PUBLIC
-${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(DUALTIMER_FILES PUBLIC
@@ -95,11 +95,11 @@ target_link_libraries(DUALTIMER_FILES PUBLIC
 add_library(EXTI_FILES STATIC)
 
 target_sources(EXTI_FILES PUBLIC
-${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/w7500x_exti.c
+${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_exti.c
         )
 
 target_include_directories(EXTI_FILES PUBLIC
-${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(EXTI_FILES PUBLIC
@@ -111,11 +111,11 @@ target_link_libraries(EXTI_FILES PUBLIC
 add_library(FLASH_FILES STATIC)
 
 target_sources(FLASH_FILES PUBLIC
-${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/w7500x_flash.c
+${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_flash.c
         )
 
 target_include_directories(FLASH_FILES PUBLIC
-${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(FLASH_FILES PUBLIC
@@ -126,11 +126,11 @@ target_link_libraries(FLASH_FILES PUBLIC
 add_library(MIIM_FILES STATIC)
 
 target_sources(MIIM_FILES PUBLIC
-${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/w7500x_miim.c
+${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_miim.c
         )
 
 target_include_directories(MIIM_FILES PUBLIC
-${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(MIIM_FILES PUBLIC
@@ -142,11 +142,11 @@ target_link_libraries(MIIM_FILES PUBLIC
 add_library(MISC_FILES STATIC)
 
 target_sources(MISC_FILES PUBLIC
-${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/w7500x_misc.c
+${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_misc.c
         )
 
 target_include_directories(MISC_FILES PUBLIC
-${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(MISC_FILES PUBLIC
@@ -157,11 +157,11 @@ target_link_libraries(MISC_FILES PUBLIC
 add_library(PWM_FILES STATIC)
 
 target_sources(PWM_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/w7500x_pwm.c
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_pwm.c
         )
 
 target_include_directories(PWM_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(PWM_FILES PUBLIC
@@ -173,11 +173,11 @@ target_link_libraries(PWM_FILES PUBLIC
 add_library(RNG_FILES STATIC)
 
 target_sources(RNG_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/w7500x_rng.c
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_rng.c
         )
 
 target_include_directories(RNG_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(RNG_FILES PUBLIC
@@ -188,11 +188,11 @@ target_link_libraries(RNG_FILES PUBLIC
 add_library(RTC_FILES STATIC)
 
 target_sources(RTC_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/w7500x_rtc.c
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_rtc.c
         )
 
 target_include_directories(RTC_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(RTC_FILES PUBLIC
@@ -203,11 +203,11 @@ target_link_libraries(RTC_FILES PUBLIC
 add_library(SSP_FILES STATIC)
 
 target_sources(SSP_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/w7500x_ssp.c
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_ssp.c
         )
 
 target_include_directories(SSP_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(SSP_FILES PUBLIC
@@ -218,11 +218,11 @@ target_link_libraries(SSP_FILES PUBLIC
 add_library(WDT_FILES STATIC)
 
 target_sources(WDT_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/w7500x_wdt.c
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_wdt.c
         )
 
 target_include_directories(WDT_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(WDT_FILES PUBLIC
@@ -234,11 +234,11 @@ target_link_libraries(WDT_FILES PUBLIC
 add_library(WZTOE_FILES STATIC)
 
 target_sources(WZTOE_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/src/w7500x_wztoe.c
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/src/w7500x_wztoe.c
         )
 
 target_include_directories(WZTOE_FILES PUBLIC
-        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_stdPeriph_Driver/inc
+        ${CMAKE_SOURCE_DIR}/Libraries/W7500x_StdPeriph_Driver/inc
         )
 
 target_link_libraries(WZTOE_FILES PUBLIC

--- a/Libraries/W7500x_StdPeriph_Driver/inc/w7500x_wztoe.h
+++ b/Libraries/W7500x_StdPeriph_Driver/inc/w7500x_wztoe.h
@@ -763,8 +763,10 @@ uipr[3] = WIZCHIP_READ((WZTOE_UIPR));
  * @param (uint8_t)ir Value to set @ref Sn_IR
  * @sa getSn_IR()
  */
+/*
 //#define setSn_IR(sn, ir) \
 //		WIZCHIP_WRITE(WZTOE_Sn_IR(sn), (ir & 0x1F))
+*/
 /**
  * @ingroup Socket_register_access_function
  * @brief Get @ref Sn_IR register
@@ -954,9 +956,11 @@ uipr[3] = WIZCHIP_READ((WZTOE_UIPR));
     WIZCHIP_WRITE((WZTOE_Sn_DHAR(sn)+0), dhar[3]); \
     WIZCHIP_WRITE((WZTOE_Sn_DHAR(sn)+5), dhar[4]); \
     WIZCHIP_WRITE((WZTOE_Sn_DHAR(sn)+4), dhar[5]); 
+/*
 //17.01.06 by justinkim
 //WIZCHIP_WRITE((WZTOE_Sn_DHAR(sn)+7), dhar[4]); \
     //WIZCHIP_WRITE((WZTOE_Sn_DHAR(sn)+6), dhar[5]); 
+*/
 
 /**
  * @ingroup Socket_register_access_function

--- a/Libraries/W7500x_StdPeriph_Driver/src/w7500x_adc.c
+++ b/Libraries/W7500x_StdPeriph_Driver/src/w7500x_adc.c
@@ -114,6 +114,7 @@ uint16_t ADC_GetConversionValue(void)
         adc_conversion_start = RESET;
         return (uint16_t) ADC->DATA;
     }
+    return 0;
 }
 
 /**

--- a/Libraries/W7500x_StdPeriph_Driver/src/w7500x_gpio.c
+++ b/Libraries/W7500x_StdPeriph_Driver/src/w7500x_gpio.c
@@ -311,6 +311,8 @@ void GPIO_WriteBit(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, BitAction BitVal)
 {
     uint32_t temp_gpio_lb;
     uint32_t temp_gpio_ub;
+    (void)temp_gpio_lb;
+    (void)temp_gpio_ub;
 
     /* Check the parameters */
     assert_param(IS_GPIO_ALL_PERIPH(GPIOx));

--- a/Libraries/W7500x_StdPeriph_Driver/src/w7500x_pwm.c
+++ b/Libraries/W7500x_StdPeriph_Driver/src/w7500x_pwm.c
@@ -64,7 +64,7 @@
  */
 void PWM_DeInit(PWM_TypeDef* PWMx)
 {
-    uint32_t tmpchannel;
+    uint32_t tmpchannel = PWM_Channel_0;
 
     /* Check the parameters */
     assert_param(IS_PWM_ALL_PERIPH(PWMx));

--- a/Libraries/W7500x_StdPeriph_Driver/src/w7500x_pwm.c
+++ b/Libraries/W7500x_StdPeriph_Driver/src/w7500x_pwm.c
@@ -64,7 +64,7 @@
  */
 void PWM_DeInit(PWM_TypeDef* PWMx)
 {
-    uint32_t tmpchannel = PWM_Channel_0;
+    uint32_t tmpchannel = 0;
 
     /* Check the parameters */
     assert_param(IS_PWM_ALL_PERIPH(PWMx));
@@ -77,6 +77,7 @@ void PWM_DeInit(PWM_TypeDef* PWMx)
     else if (PWMx == PWM5) tmpchannel = PWM_Channel_5;
     else if (PWMx == PWM6) tmpchannel = PWM_Channel_6;
     else if (PWMx == PWM7) tmpchannel = PWM_Channel_7;
+    else return;
 
     PWM->SSR &= ~tmpchannel;            // Start Stop register
     PWM->PSR &= ~tmpchannel;            // Pause register
@@ -164,7 +165,7 @@ void PWM_StructInit(PWM_InitTypeDef* PWM_InitStruct)
  */
 void PWM_Cmd(PWM_TypeDef* PWMx, FunctionalState NewState)
 {
-    uint32_t tmpchannel;
+    uint32_t tmpchannel = 0;
 
     /* Check the parameters */
     assert_param(IS_PWM_ALL_PERIPH(PWMx));
@@ -177,6 +178,7 @@ void PWM_Cmd(PWM_TypeDef* PWMx, FunctionalState NewState)
     else if (PWMx == PWM5) tmpchannel = PWM_Channel_5;
     else if (PWMx == PWM6) tmpchannel = PWM_Channel_6;
     else if (PWMx == PWM7) tmpchannel = PWM_Channel_7;
+    else return;
 
     if (NewState != DISABLE) {
         PWM->SSR |= tmpchannel;
@@ -197,7 +199,7 @@ void PWM_Cmd(PWM_TypeDef* PWMx, FunctionalState NewState)
  */
 void PWM_Pause(PWM_TypeDef* PWMx, FunctionalState NewState)
 {
-    uint32_t tmpchannel;
+    uint32_t tmpchannel = 0;
 
     /* Check the parameters */
     assert_param(IS_PWM_ALL_PERIPH(PWMx));
@@ -210,6 +212,7 @@ void PWM_Pause(PWM_TypeDef* PWMx, FunctionalState NewState)
     else if (PWMx == PWM5) tmpchannel = PWM_Channel_5;
     else if (PWMx == PWM6) tmpchannel = PWM_Channel_6;
     else if (PWMx == PWM7) tmpchannel = PWM_Channel_7;
+    else return;
 
     if (NewState != DISABLE) {
         PWM->PSR |= tmpchannel;
@@ -259,7 +262,7 @@ uint32_t PWM_GetCounter(PWM_TypeDef* PWMx)
  */
 void PWM_ITConfig(PWM_TypeDef* PWMx, uint32_t PWM_IT, FunctionalState NewState)
 {
-    uint32_t tmpchannel;
+    uint32_t tmpchannel = 0;
 
     /* Check the parameters */
     assert_param(IS_PWM_ALL_PERIPH(PWMx));
@@ -273,6 +276,7 @@ void PWM_ITConfig(PWM_TypeDef* PWMx, uint32_t PWM_IT, FunctionalState NewState)
     else if (PWMx == PWM5) tmpchannel = PWM_Channel_5;
     else if (PWMx == PWM6) tmpchannel = PWM_Channel_6;
     else if (PWMx == PWM7) tmpchannel = PWM_Channel_7;
+    else return;
 
     if (NewState != DISABLE) {
         PWM->IER |= tmpchannel;

--- a/Libraries/ioLibrary/Application/loopback/loopback.h
+++ b/Libraries/ioLibrary/Application/loopback/loopback.h
@@ -1,12 +1,12 @@
 /*******************************************************************************************************************************************************
- * Copyright ¨Ï 2016 <WIZnet Co.,Ltd.> 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ¡°Software¡±), 
+ * Copyright ï¿½ï¿½ 2016 <WIZnet Co.,Ltd.> 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ï¿½ï¿½Softwareï¿½ï¿½), 
  * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
  * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
- * THE SOFTWARE IS PROVIDED ¡°AS IS¡±, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * THE SOFTWARE IS PROVIDED ï¿½ï¿½AS ISï¿½ï¿½, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
  * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
@@ -16,7 +16,7 @@
 
 #include <stdint.h>
 #include "socket.h"
-#include "W7500x_wztoe.h"
+#include "w7500x_wztoe.h"
 
 
 /* Loopback test debug message printout enable */

--- a/Libraries/ioLibrary/Ethernet/socket.c
+++ b/Libraries/ioLibrary/Ethernet/socket.c
@@ -70,7 +70,7 @@
 //
 //*****************************************************************************
 #include "socket.h"
-#include "W7500x_wztoe.h"
+#include "w7500x_wztoe.h"
 
 #define SOCK_ANY_PORT_NUM  (0xC000) //M20160411
 

--- a/Libraries/ioLibrary/Ethernet/wizchip_conf.c
+++ b/Libraries/ioLibrary/Ethernet/wizchip_conf.c
@@ -1,12 +1,12 @@
 /*******************************************************************************************************************************************************
- * Copyright ¨Ï 2016 <WIZnet Co.,Ltd.> 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ¡°Software¡±), 
+ * Copyright ï¿½ï¿½ 2016 <WIZnet Co.,Ltd.> 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ï¿½ï¿½Softwareï¿½ï¿½), 
  * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
  * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
- * THE SOFTWARE IS PROVIDED ¡°AS IS¡±, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * THE SOFTWARE IS PROVIDED ï¿½ï¿½AS ISï¿½ï¿½, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
  * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
@@ -62,7 +62,7 @@
 //
 
 #include "wizchip_conf.h"
-#include "W7500x_wztoe.h"
+#include "w7500x_wztoe.h"
 
 /**
  * @brief Default function to enable interrupt.

--- a/Libraries/ioLibrary/Ethernet/wizchip_conf.h
+++ b/Libraries/ioLibrary/Ethernet/wizchip_conf.h
@@ -1,12 +1,12 @@
 /*******************************************************************************************************************************************************
- * Copyright ¨Ï 2016 <WIZnet Co.,Ltd.> 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ¡°Software¡±), 
+ * Copyright ï¿½ï¿½ 2016 <WIZnet Co.,Ltd.> 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ï¿½ï¿½Softwareï¿½ï¿½), 
  * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
  * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
- * THE SOFTWARE IS PROVIDED ¡°AS IS¡±, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * THE SOFTWARE IS PROVIDED ï¿½ï¿½AS ISï¿½ï¿½, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
  * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
@@ -136,8 +136,8 @@
  *       
  */
    #define _WIZCHIP_IO_MODE_           _WIZCHIP_IO_MODE_BUS_DIR_
-   //#include "W7500x_wztoe.h"
-	 #include "W7500x.h"
+   //#include "w7500x_wztoe.h"
+	 #include "w7500x.h"
 #else 
    #error "Unknown defined _WIZCHIP_. You should define one of 5100, 5200, and 5500 !!!"
 #endif

--- a/Libraries/ioLibrary/Internet/DHCP/dhcp.c
+++ b/Libraries/ioLibrary/Internet/DHCP/dhcp.c
@@ -1,12 +1,12 @@
 /*******************************************************************************************************************************************************
- * Copyright ¨Ï 2016 <WIZnet Co.,Ltd.> 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ¡°Software¡±), 
+ * Copyright ï¿½ï¿½ 2016 <WIZnet Co.,Ltd.> 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ï¿½ï¿½Softwareï¿½ï¿½), 
  * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
  * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
- * THE SOFTWARE IS PROVIDED ¡°AS IS¡±, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * THE SOFTWARE IS PROVIDED ï¿½ï¿½AS ISï¿½ï¿½, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
  * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
@@ -596,7 +596,7 @@ int8_t parseDHCPMSG(void)
 
 	uint8_t * p;
 	uint8_t * e;
-	uint8_t type;
+	uint8_t type = 0;
 	uint8_t opt_len;
 
    if((len = getSn_RX_RSR(DHCP_SOCKET)) > 0)
@@ -606,7 +606,7 @@ int8_t parseDHCPMSG(void)
       printf("DHCP message : %d.%d.%d.%d(%d) %d received. \r\n",svr_addr[0],svr_addr[1],svr_addr[2], svr_addr[3],svr_port, len);
    #endif
    }
-   else return 0;
+   else { return 0; }
 	if (svr_port == DHCP_SERVER_PORT) {
       // compare mac address
 		if ( (pDHCPMSG->chaddr[0] != DHCP_CHADDR[0]) || (pDHCPMSG->chaddr[1] != DHCP_CHADDR[1]) ||

--- a/Libraries/ioLibrary/Internet/DHCP/dhcp.h
+++ b/Libraries/ioLibrary/Internet/DHCP/dhcp.h
@@ -1,12 +1,12 @@
 /*******************************************************************************************************************************************************
- * Copyright ¨Ï 2016 <WIZnet Co.,Ltd.> 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ¡°Software¡±), 
+ * Copyright ï¿½ï¿½ 2016 <WIZnet Co.,Ltd.> 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ï¿½ï¿½Softwareï¿½ï¿½), 
  * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
  * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
- * THE SOFTWARE IS PROVIDED ¡°AS IS¡±, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * THE SOFTWARE IS PROVIDED ï¿½ï¿½AS ISï¿½ï¿½, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
  * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
@@ -59,7 +59,7 @@
 #define _DHCP_H_
 #include <stdint.h>
 #include "socket.h"
-#include "W7500x_wztoe.h"
+#include "w7500x_wztoe.h"
 /*
  * @brief 
  * @details If you want to display debug & procssing message, Define _DHCP_DEBUG_ 

--- a/Libraries/ioLibrary/Internet/DNS/dns.h
+++ b/Libraries/ioLibrary/Internet/DNS/dns.h
@@ -1,12 +1,12 @@
 /*******************************************************************************************************************************************************
- * Copyright ¨Ï 2016 <WIZnet Co.,Ltd.> 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ¡°Software¡±), 
+ * Copyright ï¿½ï¿½ 2016 <WIZnet Co.,Ltd.> 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ï¿½ï¿½Softwareï¿½ï¿½), 
  * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
  * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
- * THE SOFTWARE IS PROVIDED ¡°AS IS¡±, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * THE SOFTWARE IS PROVIDED ï¿½ï¿½AS ISï¿½ï¿½, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
  * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
@@ -65,7 +65,7 @@
 #define	_DNS_H_
 
 #include <stdint.h>
-#include "W7500x_wztoe.h"
+#include "w7500x_wztoe.h"
 /*
  * @brief Define it for Debug & Monitor DNS processing.
  * @note If defined, it dependens on <stdio.h>

--- a/Libraries/startup/cmsis_device.h
+++ b/Libraries/startup/cmsis_device.h
@@ -1,6 +1,6 @@
 #ifndef _CMSIS_H_
 #define _CMSIS_H_
 
-#include "W7500x.h"
+#include "w7500x.h"
 
 #endif // _CMSIS_H_

--- a/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Interrupt/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Interrupt/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME ADC_Interrupt)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Interrupt/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Interrupt/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Interrupt/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Interrupt/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Interrupt/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Interrupt/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Polling/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Polling/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME ADC_Polling)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Polling/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Polling/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Polling/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Polling/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Polling/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/ADC/ADC_Polling/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/DualTimer/DualTimer_BasicExample/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/DualTimer/DualTimer_BasicExample/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME DualTimer_BasicExample)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/DualTimer/DualTimer_BasicExample/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/DualTimer/DualTimer_BasicExample/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/DualTimer/DualTimer_BasicExample/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/DualTimer/DualTimer_BasicExample/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/DualTimer/DualTimer_BasicExample/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/DualTimer/DualTimer_BasicExample/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/EXTI/EXTI_BasicExample/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/EXTI/EXTI_BasicExample/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME EXTI_BasicExample)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/EXTI/EXTI_BasicExample/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/EXTI/EXTI_BasicExample/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/EXTI/EXTI_BasicExample/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/EXTI/EXTI_BasicExample/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/EXTI/EXTI_BasicExample/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/EXTI/EXTI_BasicExample/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/Flash/Flash_IAP/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/Flash/Flash_IAP/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME Flash_IAP)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/Flash/Flash_IAP/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/Flash/Flash_IAP/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/Flash/Flash_IAP/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/Flash/Flash_IAP/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/Flash/Flash_IAP/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/Flash/Flash_IAP/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_IOToggle/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_IOToggle/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME GPIO_IOToggle)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_IOToggle/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_IOToggle/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_IOToggle/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_IOToggle/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_IOToggle/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_IOToggle/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_Interrupt/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_Interrupt/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME GPIO_Interrupt)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_Interrupt/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_Interrupt/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_Interrupt/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_Interrupt/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_Interrupt/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/GPIO/GPIO_Interrupt/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CaptureMode/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CaptureMode/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME PWM_CaptureMode)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CaptureMode/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CaptureMode/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CaptureMode/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CaptureMode/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CaptureMode/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CaptureMode/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CaptureMode/w7500x_it.c
+++ b/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CaptureMode/w7500x_it.c
@@ -217,7 +217,7 @@ void PWM0_Handler(void)
     }
     if (PWM_GetITStatus(PWM0, PWM_IT_CI) == SET) {
         PWM_ClearITPendingBit(PWM0, PWM_IT_CI);
-        printf("PWM_GetCapture : %d\r\n", PWM_GetCapture(PWM0));
+        printf("PWM_GetCapture : %ld\r\n", PWM_GetCapture(PWM0));
     }
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CounterMode/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CounterMode/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME PWM_CounterMode)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CounterMode/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CounterMode/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CounterMode/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CounterMode/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CounterMode/main.c
+++ b/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CounterMode/main.c
@@ -69,7 +69,7 @@ int main(void)
         new_pwm_counter = PWM_GetCounter(PWM0);
         if (old_pwm_counter != new_pwm_counter) {
             old_pwm_counter = new_pwm_counter;
-            printf("PWM_GetCounter : %d\r\n", new_pwm_counter);
+            printf("PWM_GetCounter : %ld\r\n", new_pwm_counter);
         }
     }
 	

--- a/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CounterMode/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/PWM/PWM_CounterMode/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/PWM/PWM_DeadZoneGeneration/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/PWM/PWM_DeadZoneGeneration/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME PWM_DeadZoneGeneration)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_DeadZoneGeneration/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_DeadZoneGeneration/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_DeadZoneGeneration/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_DeadZoneGeneration/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/PWM/PWM_DeadZoneGeneration/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/PWM/PWM_DeadZoneGeneration/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/PWM/PWM_PWMOutput/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/PWM/PWM_PWMOutput/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME PWM_PWMOutput)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_PWMOutput/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_PWMOutput/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_PWMOutput/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/PWM/PWM_PWMOutput/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/PWM/PWM_PWMOutput/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/PWM/PWM_PWMOutput/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/RNG/RNG_BasicExample/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/RNG/RNG_BasicExample/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME RNG_BasicExample)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/RNG/RNG_BasicExample/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/RNG/RNG_BasicExample/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/RNG/RNG_BasicExample/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/RNG/RNG_BasicExample/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/RNG/RNG_BasicExample/main.c
+++ b/Projects/W7500x_StdPeriph_Examples/RNG/RNG_BasicExample/main.c
@@ -67,7 +67,7 @@ int main(void)
     while (1) {
         RNG_Enable(ENABLE);
         RNG_Enable(DISABLE);
-        printf("RNG : %d\r\n", RNG_GetRandomNumber() & 0x0000FFFF);
+        printf("RNG : %ld\r\n", RNG_GetRandomNumber() & 0x0000FFFF);
         Delay(800000);
     }
 	

--- a/Projects/W7500x_StdPeriph_Examples/RNG/RNG_BasicExample/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/RNG/RNG_BasicExample/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/SysTick/SysTick_BasicExample/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/SysTick/SysTick_BasicExample/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME SysTick_BasicExample)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/SysTick/SysTick_BasicExample/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/SysTick/SysTick_BasicExample/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/SysTick/SysTick_BasicExample/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/SysTick/SysTick_BasicExample/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/SysTick/SysTick_BasicExample/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/SysTick/SysTick_BasicExample/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/UART/UART_HardwareFlowControl/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/UART/UART_HardwareFlowControl/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME UART_HardwareFlowControl)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_HardwareFlowControl/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_HardwareFlowControl/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_HardwareFlowControl/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_HardwareFlowControl/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/UART/UART_HardwareFlowControl/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/UART/UART_HardwareFlowControl/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/UART/UART_Interrupt/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/UART/UART_Interrupt/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME UART_Interrupt)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_Interrupt/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_Interrupt/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_Interrupt/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_Interrupt/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/UART/UART_Interrupt/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/UART/UART_Interrupt/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/UART/UART_Polling/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/UART/UART_Polling/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME UART_Polling)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_Polling/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_Polling/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_Polling/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_Polling/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/UART/UART_Polling/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/UART/UART_Polling/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/UART/UART_Printf/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/UART/UART_Printf/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME UART_Printf)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_Printf/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_Printf/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_Printf/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/UART/UART_Printf/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/UART/UART_Printf/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/UART/UART_Printf/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/WDT/WDT_Reset/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/WDT/WDT_Reset/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TARGET_NAME WDT_Reset)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WDT/WDT_Reset/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WDT/WDT_Reset/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WDT/WDT_Reset/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WDT/WDT_Reset/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/WDT/WDT_Reset/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/WDT/WDT_Reset/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DHCPClient/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DHCPClient/CMakeLists.txt
@@ -5,9 +5,9 @@ set(TARGET_NAME WZTOE_DHCPClient)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DHCPClient/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DHCPClient/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DHCPClient/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DHCPClient/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DHCPClient/main.c
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DHCPClient/main.c
@@ -27,6 +27,7 @@
 #include "main.h"
 #include "wizchip_conf.h"
 #include "dhcp.h"
+#include <string.h>
 
 /** @addtogroup W7500x_StdPeriph_Examples
  * @{

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DHCPClient/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DHCPClient/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DNSClient/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DNSClient/CMakeLists.txt
@@ -5,9 +5,9 @@ set(TARGET_NAME WZTOE_DNSClient)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DNSClient/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DNSClient/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DNSClient/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DNSClient/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DNSClient/main.c
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DNSClient/main.c
@@ -27,6 +27,7 @@
 #include "main.h"
 #include "wizchip_conf.h"
 #include "dns.h"
+#include <string.h>
 
 /** @addtogroup W7500x_StdPeriph_Examples
  * @{

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DNSClient/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_DNSClient/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_Loopback/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_Loopback/CMakeLists.txt
@@ -5,9 +5,9 @@ set(TARGET_NAME WZTOE_Loopback)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_Loopback/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_Loopback/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_Loopback/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_Loopback/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_Loopback/main.c
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_Loopback/main.c
@@ -27,6 +27,7 @@
 #include "main.h"
 #include "wizchip_conf.h"
 #include "loopback.h"
+#include <string.h>
 
 /** @addtogroup W7500x_StdPeriph_Examples
  * @{

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_Loopback/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_Loopback/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_UDPMulticasting/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_UDPMulticasting/CMakeLists.txt
@@ -5,9 +5,9 @@ set(TARGET_NAME WZTOE_UDPMulticasting)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_UDPMulticasting/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_UDPMulticasting/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_UDPMulticasting/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_UDPMulticasting/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_UDPMulticasting/main.c
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_UDPMulticasting/main.c
@@ -27,6 +27,7 @@
 #include "main.h"
 #include "wizchip_conf.h"
 #include "loopback.h"
+#include <string.h>
 
 /** @addtogroup W7500x_StdPeriph_Examples
  * @{
@@ -155,7 +156,7 @@ switch(getSn_SR(sn))
 			printf("%d:recv : %s\t",sn, test_buf);
 			printf("%d:peer - %d.%d.%d.%d : %d\r\n",sn, udp_multi_dest_ip[0], udp_multi_dest_ip[1], udp_multi_dest_ip[2], udp_multi_dest_ip[3], udp_destport);
 #endif
-			if(strstr( test_buf, "end" ))
+			if(strstr( (char *)test_buf, "end" ))
 			{
 				close(sn);
 				printf("%d: SN_MR: 0x%02x\r\n", sn, getSn_MR(sn));
@@ -169,7 +170,7 @@ switch(getSn_SR(sn))
 
 				ret = sendto(sn, test_buf+sentsize, size-sentsize, udp_multi_dest_ip, udp_destport);
 #ifdef _LOOPBACK_DEBUG_
-				printf("multicast sendto %d\r\n", ret);
+				printf("multicast sendto %ld\r\n", ret);
 #endif
 				if(ret < 0)
 				{
@@ -182,6 +183,7 @@ switch(getSn_SR(sn))
 		}
 	break;
 	}
+    return -1;
 }
 /**
  * @brief  Configures the UART Peripheral.

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_UDPMulticasting/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_UDPMulticasting/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebClient/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebClient/CMakeLists.txt
@@ -5,9 +5,9 @@ set(TARGET_NAME WZTOE_WebClient)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebClient/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebClient/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebClient/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebClient/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebClient/main.c
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebClient/main.c
@@ -28,6 +28,7 @@
 #include "wizchip_conf.h"
 #include "dhcp.h"
 #include "dns.h"
+#include <string.h>
 
 /** @addtogroup W7500x_StdPeriph_Examples
  * @{
@@ -281,7 +282,7 @@ void dhcp_conflict(void)
  */
 int32_t WebClient(uint8_t sn, uint8_t* buf, uint8_t* destip, uint16_t destport)
 {
-    int32_t ret;
+    int32_t ret = 0;
     uint16_t size = 0;
     uint16_t any_port = 50000;
 
@@ -297,7 +298,7 @@ int32_t WebClient(uint8_t sn, uint8_t* buf, uint8_t* destip, uint16_t destport)
 
             setSn_IR(sn, Sn_IR_CON);
 
-            ret = send(sn, "GET /search?q=w7500x HTTP/1.1\r\n"
+            ret = send(sn, (uint8_t *)"GET /search?q=w7500x HTTP/1.1\r\n"
                     "Host: www.google.com\r\n"
                     "Connection: close\r\n"
                     "\r\n", sizeof("GET /search?q=w7500 HTTP/1.1\r\n"
@@ -317,6 +318,7 @@ int32_t WebClient(uint8_t sn, uint8_t* buf, uint8_t* destip, uint16_t destport)
             printf("%s", buf);
         }
     }
+    return -1;
 }
 
 

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebClient/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebClient/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebServer/CMakeLists.txt
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebServer/CMakeLists.txt
@@ -5,9 +5,9 @@ set(TARGET_NAME WZTOE_WebServer)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebServer/main.c 
-  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebServer/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebServer/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebServer/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebServer/main.c
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebServer/main.c
@@ -27,6 +27,7 @@
 #include "main.h"
 #include "wizchip_conf.h"
 #include "dhcp.h"
+#include <string.h>
 
 /** @addtogroup W7500x_StdPeriph_Examples
  * @{
@@ -299,7 +300,7 @@ int32_t WebServer(uint8_t sn, uint8_t* buf, uint16_t port)
                 if (ret <= 0) return ret;
                 printf("%s", buf);
 
-                ret = send(sn, "HTTP/1.1 200 OK\r\n"
+                ret = send(sn, (uint8_t *)"HTTP/1.1 200 OK\r\n"
                         "Content-Type: text/html\r\n"
                         "Connection: close\r\n"
                         "Refresh: 5\r\n"
@@ -323,8 +324,8 @@ int32_t WebServer(uint8_t sn, uint8_t* buf, uint16_t port)
                     else if (i < 2) adcChannelOffset = 2;
                     ADC_ChannelConfig(i+adcChannelOffset);
                     ADC_StartOfConversion();
-                    sprintf(adc_buf, "analog input %d is %d<br />\r\n", i+adcChannelOffset, ADC_GetConversionValue());
-                    ret = send(sn, adc_buf, strlen(adc_buf));
+                    sprintf((char *)adc_buf, "analog input %d is %d<br />\r\n", i+adcChannelOffset, ADC_GetConversionValue());
+                    ret = send(sn, adc_buf, strlen((char *)adc_buf));
                     if (ret < 0) {
                         close(sn);
                         return ret;
@@ -333,7 +334,7 @@ int32_t WebServer(uint8_t sn, uint8_t* buf, uint16_t port)
                     memset(adc_buf, '\0', 128);
                 }
 
-                ret = send(sn, "</html>\r\n", sizeof("</html>\r\n") - 1);
+                ret = send(sn, (uint8_t *)"</html>\r\n", sizeof("</html>\r\n") - 1);
                 if (ret < 0) {
                     close(sn);
                     return ret;

--- a/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebServer/retarget.c
+++ b/Projects/W7500x_StdPeriph_Examples/WZTOE/WZTOE_WebServer/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **Please refer to [getting_started.md](getting_started.md) for examples usage.**
 
+For Linux users refer to [getting_started-linux.md](./getting_started-linux.md) to build the firmware.
 <br />
 
 # W7500x-Surf5

--- a/getting_started-linux.md
+++ b/getting_started-linux.md
@@ -1,0 +1,20 @@
+# Surf 5 User Guide for Linux (Debian Based)
+
+**Click this [Surf 5 Github Link](https://github.com/Wiznet/W7500x-Surf5/) link to access GitHub, and download the Surf5 project.**
+
+## Installing Build Dependencies
+
+```sh
+sudo apt install gcc-arm-none-eabi binutils-arm-none-eabi \
+    libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib \
+    libstdc++-arm-none-eabi-dev \
+    gdb cmake make
+```
+
+## Start CMAKE generation
+
+Open a terminal into the `W7500x-Surf5` directory :
+
+```sh
+cmake -B build
+```

--- a/getting_started-linux.md
+++ b/getting_started-linux.md
@@ -21,3 +21,12 @@ cmake -B build
 
 Finally go into the `build` directory where the files are generated
 and Run `make` to build everything.
+
+### For debugging `make` output
+
+```sh
+make > build.txt 2>&1
+```
+
+This would fill the complete output of `make` along with errors
+into the `build.txt` file inside the `build` directory.

--- a/getting_started-linux.md
+++ b/getting_started-linux.md
@@ -18,3 +18,6 @@ Open a terminal into the `W7500x-Surf5` directory :
 ```sh
 cmake -B build
 ```
+
+Finally go into the `build` directory where the files are generated
+and Run `make` to build everything.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,9 +5,9 @@ set(TARGET_NAME src)
 add_executable(${TARGET_NAME}
 
   ${CMAKE_SOURCE_DIR}/src/main.c 
-  ${CMAKE_SOURCE_DIR}/src/W7500x_it.c
+  ${CMAKE_SOURCE_DIR}/src/w7500x_it.c
   ${CMAKE_SOURCE_DIR}/src/retarget.c
-  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_w7500.s
+  ${CMAKE_SOURCE_DIR}/Libraries/CMSIS/Device/WIZnet/W7500/Source/GCC/startup_W7500.s
   )
 
 target_include_directories(${TARGET_NAME} PUBLIC

--- a/src/retarget.c
+++ b/src/retarget.c
@@ -125,7 +125,7 @@ void UartPuts(UART_TypeDef* UARTx, uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             UartPutc(UARTx, ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 
@@ -153,7 +153,7 @@ void S_UartPuts(uint8_t *str)
         if (ch != (uint8_t) 0x0) {
             S_UART_SendData(ch);
         }
-        *str++;
+        (void)*str++;
     } while (ch != 0);
 }
 

--- a/tools/arm-none-eabi-gcc.cmake
+++ b/tools/arm-none-eabi-gcc.cmake
@@ -1,16 +1,31 @@
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR ARM)
 
-#set(ARM_TOOLCHAIN_DIR "D:/tools/gcc-arm-none-eabi-9-2020-q2-update-win32/bin")
+if (UNIX OR LINUX)
+# For Linux
+set(ARM_TOOLCHAIN_DIR "/usr/bin")
+elseif (WIN32 OR MSVC)
+# For Windows
+set(ARM_TOOLCHAIN_DIR "C:/Program Files (x86)/GNU Arm Embedded Toolchain/10 2021.10/bin")
+endif()
+
 set(BINUTILS_PATH ${ARM_TOOLCHAIN_DIR})
 
 set(TOOLCHAIN_PREFIX ${ARM_TOOLCHAIN_DIR}/arm-none-eabi-)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
+if (UNIX OR LINUX)
+# For Linux
+set(CMAKE_C_COMPILER "${TOOLCHAIN_PREFIX}gcc" CACHE FILEPATH "C Compiler path")
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+set(CMAKE_CXX_COMPILER "${TOOLCHAIN_PREFIX}g++" CACHE FILEPATH "C++ Compiler path")
+elseif (WIN32 OR MSVC)
+# For Windows
 set(CMAKE_C_COMPILER "${TOOLCHAIN_PREFIX}gcc.exe" CACHE FILEPATH "C Compiler path")
 set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
 set(CMAKE_CXX_COMPILER "${TOOLCHAIN_PREFIX}g++.exe" CACHE FILEPATH "C++ Compiler path")
+endif()
 
 set(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}objcopy CACHE INTERNAL "objcopy tool")
 set(CMAKE_SIZE_UTIL ${TOOLCHAIN_PREFIX}size CACHE INTERNAL "size tool")


### PR DESCRIPTION
- Cleaning up all Warnings
- Fix to Standard library for pwm library
- Fix ioLibrary
- Fix Example warnings
- Support for automatic selection of platform tools in CMAKE
- Initial Linux build support `getting_started-linux.md`